### PR TITLE
Add support for recurring games

### DIFF
--- a/.env template
+++ b/.env template
@@ -1,0 +1,10 @@
+HOST="" # host for web frontend
+MONGODB_URL=""
+TOKEN="" # discord bot token
+PORT=""
+LOCALENV=""
+SLEEP=""
+CLIENT_ID="" # discord
+CLIENT_SECRET="" # discord
+INVITE="" # discord oauth2 redirect to /invite page, use identify/guilds perms
+AUTH_URL="" # discord oauth2 redirect to /login page, use identify/guilds perms

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ app/
 
 # DynamoDB Local files
 .dynamodb/
+
+# vscode workspace file
+*.code-workspace

--- a/README.md
+++ b/README.md
@@ -156,6 +156,27 @@ https://rpg-schedule.herokuapp.com
 </tbody>
 </table>
 
+## How to Develop
+* install [git](https://git-scm.com/downloads), [node](https://nodejs.org/en/download/), [heroku-cli](https://devcenter.heroku.com/articles/heroku-cli#download-and-install), [mongodb server](https://www.mongodb.com/download-center/community)
+* `npm i`
+* [set up discord bot with perms and token](https://discordapp.com/developers)
+  * permissions: 
+    * send messages
+    * manage messages
+    * embed links
+    * read message history
+    * add reactions
+  * OAuth2 redirects
+    * `http://localhost:5000/invite`
+      * guilds
+      * identify
+    * `http://localhost:5000/login`
+      * guilds
+      * identify
+* copy `.env template` to `.env` and fill out values
+* start `mongod`
+* `heroku local`
+
 ## About the bot
 
 The discord bot is deployed with Heroku as a Node.js and discord.js application and MongoDB for data storage. When an update is pushed to this repository, the update is automatically deployed to Heroku.

--- a/lang/en.json
+++ b/lang/en.json
@@ -34,6 +34,8 @@
     "SIGN_UP_METHOD": "Sign Up Method",
     "WHEN": "When",
     "CUSTOM_SIGNUP_INSTRUCTIONS": "Custom Signup Instructions",
+    "FREQUENCY": "Frequency",
+    "WEEKDAYS": "Weekdays",
     "DATE": "Date",
     "TIME": "Time",
     "TIME_ZONE": "Time Zone",
@@ -51,6 +53,7 @@
     "MAX": "Max",
     "CHARACTERS": "characters",
     "NO_PLAYERS": "No players",
+    "NEXT_DATE": "Next Scheduled Date",
     "options": {
       "AUTOMATED_SIGNUP": "Automated Signup",
       "CUSTOM_SIGNUP_INSTRUCTIONS": "Custom Signup Instructions",
@@ -62,7 +65,19 @@
       "MINUTES_60": "1 hour",
       "HOURS_6": "6 hours",
       "HOURS_12": "12 hours",
-      "HOURS_24": "24 hours"
+      "HOURS_24": "24 hours",
+      "NO_REPEAT": "Does Not Repeat",
+      "DAILY": "Every Day",
+      "WEEKLY": "Every Week",
+      "BIWEEKLY": "Every Two Weeks",
+      "MONTHLY": "Every Month",
+      "MONDAY_SHORT": "Mon",
+      "TUESDAY_SHORT": "Tue",
+      "WEDNESDAY_SHORT": "Wed",
+      "THURSDAY_SHORT": "Thu",
+      "FRIDAY_SHORT": "Fri",
+      "SATURDAY_SHORT": "Sat",
+      "SUNDAY_SHORT": "Sun"
     },
     "labels": {
       "HOURS": "hours",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rpg-schedule",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2438,6 +2438,11 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha1-DQVdU/UFKqZTyfbraLtdEr9cK1s="
+    },
+    "moment-recur-ts": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/moment-recur-ts/-/moment-recur-ts-1.3.1.tgz",
+      "integrity": "sha1-L+GwML2IPikiTwfg+AjXWYGHOh0="
     },
     "mongodb": {
       "version": "3.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpg-schedule",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A discord bot for announcing RPG games with automated sign up",
   "main": "index.js",
   "dependencies": {
@@ -24,6 +24,7 @@
     "express-session": "^1.16.1",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
+    "moment-recur-ts": "^1.3.1",
     "mongodb": "^3.1.10",
     "nodemon": "^1.18.9",
     "object.fromentries": "^2.0.0",

--- a/public/scripts/moment-recur.js
+++ b/public/scripts/moment-recur.js
@@ -1,0 +1,727 @@
+(function (root, factory) {
+	if (typeof exports === 'object') {
+			module.exports = factory(require('moment'));
+	} else if (typeof define === 'function' && define.amd) {
+			define('moment-recur', ['moment'], factory);
+	} else {
+			root.moment = factory(root.moment);
+	}
+}(this, function (moment) {
+	var hasModule;
+
+	hasModule = (typeof module !== "undefined" && module !== null) && (module.exports != null);
+
+	if (typeof moment === 'undefined') {
+		throw Error("Can't find moment");
+	}
+
+	// Interval object for creating and matching interval-based rules
+	var Interval = (function() {
+			function createInterval(units, measure) {
+					// Make sure all of the units are integers greater than 0.
+					for (var unit in units) {
+							if (units.hasOwnProperty(unit)) {
+									if (parseInt(unit, 10) <= 0) {
+											throw Error('Intervals must be greater than zero');
+									}
+							}
+					}
+
+					return {
+							measure: measure.toLowerCase(),
+							units: units
+					};
+			}
+
+			function matchInterval(type, units, start, date) {
+					// Get the difference between the start date and the provided date,
+					// using the required measure based on the type of rule'
+					var diff = null;
+					if (date.isBefore(start)) {
+							diff = start.diff(date, type, true);
+					} else {
+							diff = date.diff(start, type, true);
+					}
+					if (type == 'days') {
+							// if we are dealing with days, we deal with whole days only.
+							diff = parseInt(diff);
+					}
+
+					// Check to see if any of the units provided match the date
+					for (var unit in units) {
+							if (units.hasOwnProperty(unit)) {
+									unit = parseInt(unit, 10);
+
+									// If the units divide evenly into the difference, we have a match
+									if ((diff % unit) === 0) {
+											return true;
+									}
+							}
+					}
+
+					return false;
+			}
+
+			return {
+				create: createInterval,
+				match: matchInterval
+			};
+	})();
+
+	// Calendar object for creating and matching calendar-based rules
+	var Calendar = (function (){
+			// Dictionary of unit types based on measures
+			var unitTypes = {
+					"daysOfMonth": "date",
+					"daysOfWeek": "day",
+					"weeksOfMonth": "monthWeek",
+					"weeksOfMonthByDay": "monthWeekByDay",
+					"weeksOfYear": "week",
+					"monthsOfYear": "month"
+			};
+
+			// Dictionary of ranges based on measures
+			var ranges = {
+					"daysOfMonth"       : { low: 1, high: 31 },
+					"daysOfWeek"        : { low: 0, high: 6 },
+					"weeksOfMonth"      : { low: 0, high: 4 },
+					"weeksOfMonthByDay" : { low: 0, high: 4 },
+					"weeksOfYear"       : { low: 0, high: 52 },
+					"monthsOfYear"      : { low: 0, high: 11 }
+			};
+
+			// Private function for checking the range of calendar values
+			function checkRange(low, high, list) {
+					list.forEach(function(v) {
+							if (v < low || v > high) {
+									throw Error('Value should be in range ' + low + ' to ' + high);
+							}
+					});
+			}
+
+			// Private function to convert day and month names to numbers
+			function namesToNumbers(list, nameType) {
+					var unit, unitInt, unitNum;
+					var newList = {};
+
+					for(unit in list) {
+							if (list.hasOwnProperty(unit)) {
+									unitInt = parseInt(unit, 10);
+
+									if (isNaN(unitInt)) {
+											unitInt = unit;
+									}
+
+									unitNum = moment().set(nameType, unitInt).get(nameType);
+									newList[unitNum] = list[unit];
+							}
+					}
+
+					return newList;
+			}
+
+			function createCalendarRule(list, measure) {
+					var keys = [];
+
+					// Convert day/month names to numbers, if needed
+					if (measure === "daysOfWeek") {
+							list = namesToNumbers(list, "days");
+					}
+
+					if (measure === "monthsOfYear") {
+							list = namesToNumbers(list, "months");
+					}
+
+					for (var key in list) if (hasOwnProperty.call(list, key)) keys.push(key);
+
+					// Make sure the listed units are in the measure's range
+					checkRange(ranges[measure].low,
+										 ranges[measure].high,
+										 keys);
+
+					return {
+							measure: measure,
+							units: list
+					};
+			}
+
+			function matchCalendarRule(measure, list, date) {
+					// Get the unit type (i.e. date, day, week, monthWeek, weeks, months)
+					var unitType = unitTypes[measure];
+
+					// Get the unit based on the required measure of the date
+					var unit = date[unitType]();
+
+					// If the unit is in our list, return true, else return false
+					if (list[unit]) {
+							return true;
+					}
+
+					// match on end of month days
+					if (unitType === 'date' && unit == date.add(1, 'months').date(0).format('D') && unit < 31) {
+							while (unit <= 31) {
+									if (list[unit]) {
+											return true;
+									}
+									unit++;
+							}
+					}
+
+					return false;
+			}
+
+			return {
+					create: createCalendarRule,
+					match: matchCalendarRule
+			};
+	})();
+
+	// The main Recur object to provide an interface for settings, rules, and matching
+	var Recur = (function() {
+
+			// A dictionary used to match rule measures to rule types
+			var ruleTypes = {
+					"days": "interval",
+					"weeks": "interval",
+					"months": "interval",
+					"years": "interval",
+					"daysOfWeek": "calendar",
+					"daysOfMonth": "calendar",
+					"weeksOfMonth": "calendar",
+					"weeksOfMonthByDay": "calendar",
+					"weeksOfYear": "calendar",
+					"monthsOfYear": "calendar"
+			};
+
+			// a dictionary of plural and singular measures
+			var measures = {
+					"days": "day",
+					"weeks": "week",
+					"months": "month",
+					"years": "year",
+					"daysOfWeek": "dayOfWeek",
+					"daysOfMonth": "dayOfMonth",
+					"weeksOfMonth": "weekOfMonth",
+					"weeksOfMonthByDay": "weekOfMonthByDay",
+					"weeksOfYear": "weekOfYear",
+					"monthsOfYear": "monthOfYear"
+			};
+
+
+			/////////////////////////////////
+			// Private Methods             //
+			// Must be called with .call() //
+			/////////////////////////////////
+
+			// Private method that tries to set a rule.
+			function trigger() {
+					var rule;
+					var ruleType = ruleTypes[this.measure];
+
+					if (!(this instanceof Recur)) {
+							throw Error("Private method trigger() was called directly or not called as instance of Recur!");
+					}
+
+					// Make sure units and measure is defined and not null
+					if ((typeof this.units === "undefined" || this.units === null) || !this.measure) {
+							return this;
+					}
+
+					// Error if we don't have a valid ruleType
+					if (ruleType !== "calendar" && ruleType !== "interval") {
+							throw Error("Invalid measure provided: " + this.measure);
+					}
+
+					// Create the rule
+					if (ruleType === "interval") {
+							if (!this.start) {
+									throw Error("Must have a start date set to set an interval!");
+							}
+
+							rule = Interval.create(this.units, this.measure);
+					}
+
+					if (ruleType === "calendar") {
+							rule = Calendar.create(this.units, this.measure);
+					}
+
+					// Remove the temporary rule data
+					this.units = null;
+					this.measure = null;
+
+					if (rule.measure === 'weeksOfMonthByDay' && !this.hasRule('daysOfWeek')) {
+							throw Error("weeksOfMonthByDay must be combined with daysOfWeek");
+					}
+
+					// Remove existing rule based on measure
+					for (var i = 0; i < this.rules.length; i++) {
+							if (this.rules[i].measure === rule.measure) {
+									this.rules.splice(i, 1);
+							}
+					}
+
+					this.rules.push(rule);
+					return this;
+			}
+
+			// Private method to get next, previous or all occurrences
+			function getOccurrences(num, format, type) {
+					var currentDate, date;
+					var dates = [];
+
+					if (!(this instanceof Recur)) {
+							throw Error("Private method trigger() was called directly or not called as instance of Recur!");
+					}
+
+					if (!this.start && !this.from) {
+							throw Error("Cannot get occurrences without start or from date.");
+					}
+
+					if (type === "all" && !this.end) {
+							throw Error("Cannot get all occurrences without an end date.");
+					}
+
+					if (!!this.end && (this.start > this.end)) {
+							throw Error("Start date cannot be later than end date.");
+					}
+
+					// Return empty set if the caller doesn't want any for next/prev
+					if (type !== "all" && !(num > 0)) {
+							return dates;
+					}
+
+					// Start from the from date, or the start date if from is not set.
+					currentDate = (this.from || this.start).clone();
+
+					// Include the initial date in the results if wanting all dates
+					if (type === "all") {
+							if (this.matches(currentDate, false)) {
+									date = format ? currentDate.format(format) : currentDate.clone();
+									dates.push(date);
+							}
+					}
+
+					// Get the next N dates, if num is null then infinite
+					while (dates.length < (num===null ? dates.length+1 : num)) {
+							if (type === "next" || type === "all") {
+									currentDate.add(1, "day");
+							} else {
+									currentDate.subtract(1, "day");
+							}
+
+							//console.log("Match: " + currentDate.format("L") + " - " + this.matches(currentDate, true));
+
+							// Don't match outside the date if generating all dates within start/end
+							if (this.matches(currentDate, (type==="all"?false:true))) {
+									date = format ? currentDate.format(format) : currentDate.clone();
+									dates.push(date);
+							}
+							if(currentDate >= this.end) {
+									break;
+							}
+					}
+
+					return dates;
+			}
+
+
+			///////////////////////
+			// Private Functions //
+			///////////////////////
+
+			// Private function to see if a date is within range of start/end
+			function inRange(start, end, date) {
+					if (start && date.isBefore(start)) { return false; }
+					if (end && date.isAfter(end)) { return false; }
+					return true;
+			}
+
+			// Private function to turn units into objects
+			function unitsToObject(units) {
+					var list = {};
+
+					if (Object.prototype.toString.call(units) == '[object Array]') {
+							units.forEach(function(v) {
+									list[v] = true;
+							});
+					} else if (units === Object(units)) {
+							list = units;
+					} else if ((Object.prototype.toString.call(units) == '[object Number]') || (Object.prototype.toString.call(units) == '[object String]')) {
+							list[units] = true;
+					} else {
+							throw Error("Provide an array, object, string or number when passing units!");
+					}
+
+					return list;
+			}
+
+			// Private function to check if a date is an exception
+			function isException(exceptions, date) {
+					for (var i = 0, len = exceptions.length; i < len; i++) {
+							if (moment(exceptions[i]).isSame(date)) {
+									return true;
+							}
+					}
+					return false;
+			}
+
+			// Private function to pluralize measure names for use with dictionaries.
+			function pluralize(measure) {
+					switch(measure) {
+							case "day":
+									return "days";
+
+							case "week":
+									return "weeks";
+
+							case "month":
+									return "months";
+
+							case "year":
+									return "years";
+
+							case "dayOfWeek":
+									return "daysOfWeek";
+
+							case "dayOfMonth":
+									return "daysOfMonth";
+
+							case "weekOfMonth":
+									return "weeksOfMonth";
+
+							case "weekOfMonthByDay":
+									return "weeksOfMonthByDay";
+
+							case "weekOfYear":
+									return "weeksOfYear";
+
+							case "monthOfYear":
+									return "monthsOfYear";
+
+							default:
+									return measure;
+					}
+			}
+
+			// Private funtion to see if all rules match
+			function matchAllRules(rules, date, start) {
+					var i, len, rule, type;
+
+					for (i = 0, len = rules.length; i < len; i++) {
+							rule = rules[i];
+							type = ruleTypes[rule.measure];
+
+							if (type === "interval") {
+									if (!Interval.match(rule.measure, rule.units, start, date)) {
+											return false;
+									}
+							} else if (type === "calendar") {
+									if (!Calendar.match(rule.measure, rule.units, date)) {
+											return false;
+									}
+							} else {
+									return false;
+							}
+					}
+
+					return true;
+			}
+
+			// Private function to create measure functions
+			function createMeasure(measure) {
+					return function(units) {
+							this.every.call(this, units, measure);
+							return this;
+					};
+			}
+
+
+			//////////////////////
+			// Public Functions //
+			//////////////////////
+
+			// Recur Object Constrcutor
+			var Recur = function(options) {
+					if (options.start) {
+							this.start = moment(options.start).dateOnly();
+					}
+
+					if (options.end) {
+							this.end = moment(options.end).dateOnly();
+					}
+
+					// Our list of rules, all of which must match
+					this.rules = options.rules || [];
+
+					// Our list of exceptions. Match always fails on these dates.
+					var exceptions = options.exceptions || [];
+					this.exceptions = [];
+					for(var i = 0; i < exceptions.length; i++) {
+							this.except(exceptions[i]);
+					}
+
+					// Temporary units integer, array, or object. Does not get imported/exported.
+					this.units = null;
+
+					// Temporary measure type. Does not get imported/exported.
+					this.measure = null;
+
+					// Temporary from date for next/previous. Does not get imported/exported.
+					this.from = null;
+
+					return this;
+			};
+
+			// Get/Set start date
+			Recur.prototype.startDate = function(date) {
+					if (date === null) {
+							this.start = null;
+							return this;
+					}
+
+					if (date) {
+							this.start = moment(date).dateOnly();
+							return this;
+					}
+
+					return this.start;
+			};
+
+			// Get/Set end date
+			Recur.prototype.endDate = function(date) {
+					if (date === null) {
+							this.end = null;
+							return this;
+					}
+
+					if (date) {
+							this.end = moment(date).dateOnly();
+							return this;
+					}
+
+					return this.end;
+			};
+
+			// Get/Set a temporary from date
+			Recur.prototype.fromDate = function(date) {
+					 if (date === null) {
+							this.from = null;
+							return this;
+					}
+
+					if (date) {
+							this.from = moment(date).dateOnly();
+							return this;
+					}
+
+					return this.from;
+			};
+
+			// Export the settings, rules, and exceptions of this recurring date
+			Recur.prototype.save = function() {
+					var data = {};
+
+					if (this.start && moment(this.start).isValid()) {
+							data.start = this.start.format("L");
+					}
+
+					if (this.end && moment(this.end).isValid()) {
+							data.end = this.end.format("L");
+					}
+
+					data.exceptions = [];
+					for (var i = 0, len = this.exceptions.length; i < len; i++) {
+							data.exceptions.push(this.exceptions[i].format("L"));
+					}
+
+					data.rules = this.rules;
+
+					return data;
+			};
+
+			// Return boolean value based on whether this date repeats (has rules or not)
+			Recur.prototype.repeats = function() {
+					if (this.rules.length > 0) {
+							return true;
+					}
+
+					return false;
+			};
+
+			// Set the units and, optionally, the measure
+			Recur.prototype.every = function(units, measure) {
+
+					if ((typeof units !== "undefined") && (units !== null)) {
+							this.units = unitsToObject(units);
+					}
+
+					if ((typeof measure !== "undefined") && (measure !== null)) {
+							this.measure = pluralize(measure);
+					}
+
+					return trigger.call(this);
+			};
+
+			// Creates an exception date to prevent matches, even if rules match
+			Recur.prototype.except = function(date) {
+					date = moment(date).dateOnly();
+					this.exceptions.push(date);
+					return this;
+			};
+
+			// Forgets rules (by passing measure) and exceptions (by passing date)
+			Recur.prototype.forget = function(dateOrRule) {
+					var i, len;
+					var whatMoment = moment(dateOrRule);
+
+					// If valid date, try to remove it from exceptions
+					if (whatMoment.isValid()) {
+							whatMoment = whatMoment.dateOnly(); // change to date only for perfect comparison
+							for (i = 0, len = this.exceptions.length; i < len; i++) {
+									if (whatMoment.isSame(this.exceptions[i])) {
+											this.exceptions.splice(i, 1);
+											return this;
+									}
+							}
+
+							return this;
+					}
+
+					// Otherwise, try to remove it from the rules
+					for (i = 0, len = this.rules.length; i < len; i++) {
+							if (this.rules[i].measure === pluralize(dateOrRule)) {
+									this.rules.splice(i, 1);
+							}
+					}
+			};
+
+			// Checks if a rule has been set on the chain
+			Recur.prototype.hasRule = function(measure) {
+					var i, len;
+					for (i = 0, len = this.rules.length; i < len; i++) {
+							if (this.rules[i].measure === pluralize(measure)) {
+									return true;
+							}
+					}
+					return false;
+			};
+
+			// Attempts to match a date to the rules
+			Recur.prototype.matches = function(dateToMatch, ignoreStartEnd) {
+					var date = moment(dateToMatch).dateOnly();
+
+					if (!date.isValid()) {
+							throw Error("Invalid date supplied to match method: " + dateToMatch);
+					}
+
+					if (!ignoreStartEnd && !inRange(this.start, this.end, date)) { return false }
+
+					if (isException(this.exceptions, date)) { return false; }
+
+					if (!matchAllRules(this.rules, date, this.start)) { return false; }
+
+					// if we passed everything above, then this date matches
+					return true;
+			};
+
+			// Get next N occurrences
+			Recur.prototype.next = function(num, format) {
+					return getOccurrences.call(this, num, format, "next");
+			};
+
+			// Get previous N occurrences
+			Recur.prototype.previous = function(num, format) {
+					return getOccurrences.call(this, num, format, "previous");
+			};
+
+			// Get all occurrences between start and end date
+			Recur.prototype.all = function(format) {
+					return getOccurrences.call(this, null, format, "all");
+			};
+
+			// Create the measure functions (days(), months(), daysOfMonth(), monthsOfYear(), etc.)
+			for (var measure in measures) {
+					if (ruleTypes.hasOwnProperty(measure)) {
+							Recur.prototype[measure] = Recur.prototype[measures[measure]] = createMeasure(measure);
+					}
+			}
+
+			return Recur;
+	}());
+
+	// Recur can be created the following ways:
+	// moment.recur()
+	// moment.recur(options)
+	// moment.recur(start)
+	// moment.recur(start, end)
+	moment.recur = function(start, end) {
+			// If we have an object, use it as a set of options
+			if (start === Object(start) && !moment.isMoment(start)) {
+					return new Recur(start);
+			}
+
+			// else, use the values passed
+			return new Recur({ start: start, end: end });
+	};
+
+	// Recur can also be created the following ways:
+	// moment().recur()
+	// moment().recur(options)
+	// moment().recur(start, end)
+	// moment(start).recur(end)
+	// moment().recur(end)
+	moment.fn.recur = function(start, end) {
+			// If we have an object, use it as a set of options
+			if (start === Object(start) && !moment.isMoment(start)) {
+					// if we have no start date, use the moment
+					if (typeof start.start === 'undefined') {
+							start.start = this;
+					}
+
+					return new Recur( start );
+			}
+
+			// if there is no end value, use the start value as the end
+			if (!end) {
+					end = start;
+					start = undefined;
+			}
+
+			// use the moment for the start value
+			if (!start) {
+					start = this;
+			}
+
+			return new Recur({ start: start, end: end, moment: this });
+	};
+
+	// Plugin for calculating the week of the month of a date
+	moment.fn.monthWeek = function() {
+			// First day of the first week of the month
+			var week0 = this.clone().startOf("month").startOf("week");
+
+			// First day of week
+			var day0 = this.clone().startOf("week");
+
+			return day0.diff(week0, "weeks");
+	};
+
+	// Plugin for calculating the occurrence of the day of the week in the month.
+	// Similar to `moment().monthWeek()`, the return value is zero-indexed.
+	// A return value of 2 means the date is the 3rd occurence of that day
+	// of the week in the month.
+	moment.fn.monthWeekByDay = function(date) {
+			return Math.floor((this.date()-1)/7);
+	};
+
+	// Plugin for removing all time information from a given date
+	moment.fn.dateOnly = function() {
+			if (this.tz && typeof(moment.tz) == 'function') {
+					return moment.tz(this.format('YYYY-MM-DD[T]00:00:00Z'), 'UTC');
+			} else {
+					return this.hours(0).minutes(0).seconds(0).milliseconds(0).add(this.utcOffset(), "minute").utcOffset(0);
+			}
+	};
+
+	return moment;
+}));

--- a/public/styles/game.css
+++ b/public/styles/game.css
@@ -112,3 +112,11 @@ input[readonly], input[disabled] {
 #events-list .game .buttons .btn {
     border-radius: 0;
 }
+
+#weekdays-selector .btn {
+    width: 60px;
+}
+
+#weekdays-selector .btn-secondary:not(:disabled):not(.disabled).active {
+    background-color: cornflowerblue;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,10 +79,16 @@ const client = discord.processes({
     if (!process.env.LOCALENV) {
       discord.refreshMessages();
 
-      // Once per day, prune games from the database that are more than 48 hours old
+      // Once per hour, prune games from the database that are more than 48 hours old
       discord.pruneOldGames();
       setInterval(() => {
         discord.pruneOldGames();
+      }, 3600 * 1000); // 1 hour
+
+      // Once per hour, reschedule recurring games from the database that have already occurred
+      discord.rescheduleOldGames();
+      setInterval(() => {
+        discord.rescheduleOldGames();
       }, 3600 * 1000); // 1 hour
 
       // Post Game Reminders

--- a/src/routes/game.ts
+++ b/src/routes/game.ts
@@ -113,6 +113,14 @@ export default (options: any) => {
             timezone: "",
             reminder: "0",
             gameImage: "",
+            frequency: "",
+            monday: false,
+            tuesday: false,
+            wednesday: false,
+            thursday: false,
+            friday: false,
+            saturday: false,
+            sunday: false,
             is: {
               newgame: !req.query.g ? true : false,
               editgame: req.query.g ? true : false,
@@ -151,6 +159,12 @@ export default (options: any) => {
             Object.entries(req.body).forEach(([key, value]) => {
               game[key] = value;
             });
+
+            const weekdays = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
+            for (const day of weekdays) {
+              game[day] = (req.body[day]? true : false); // have to manually re-set falses b/c form data isn't sent if the checkbox is not checked
+              data[day] = game[day];
+            }
 
             game
               .save()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
         "target": "es5",
         "allowJs": true,
         "esModuleInterop": true,
-        "removeComments": true
+        "removeComments": true,
+        "sourceMap": true
     },
     "include": [
         "./src/**/*"

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -7,6 +7,7 @@
     
     <link rel="stylesheet" href="/styles/game.css">
     <script src="/scripts/moment.js"></script>
+    <script src="/scripts/moment-recur.js"></script>
 
     <% if (is.editgame) { %>
         <script src="/scripts/socket.io.js"></script>
@@ -28,7 +29,7 @@
             <%= errors.other %>
         </div>
     <% } %>
-    <form method="post">
+    <form method="post" id="gameForm">
         <div class="row">
             <div class="form-group col-sm-6">
                 <label for="guild" class="col-form-label"><%= lang.game.SERVER %></label>
@@ -161,6 +162,55 @@
             </div>
         </div>
         <div class="row">
+            <div class="form-group col-sm-3">
+                <label for="frequency" class="col-form-label"><%= lang.game.FREQUENCY %></label>
+                <select class="form-control" id="frequency" name="frequency">
+                    <option value="0" <%= frequency === '0' ? 'selected' : '' %>><%= lang.game.options.NO_REPEAT %></option>
+                    <option value="1" <%= frequency === '1' ? 'selected' : '' %>><%= lang.game.options.DAILY %></option>
+                    <option value="2" <%= frequency === '2' ? 'selected' : '' %>><%= lang.game.options.WEEKLY %></option>
+                    <option value="3" <%= frequency === '3' ? 'selected' : '' %>><%= lang.game.options.BIWEEKLY %></option>
+                    <option value="4" <%= frequency === '4' ? 'selected' : '' %>><%= lang.game.options.MONTHLY %></option>
+                </select>
+            </div>
+            <div class="form-group col-sm-6">
+                <label for="weekdays-selector" class="col-form-label"><%= lang.game.WEEKDAYS %></label>
+                <div id="weekdays-selector" class="btn-group-toggle" data-toggle="buttons">
+                    <label <%- sunday ? 'class="btn btn-secondary active"' : 'class="btn btn-secondary"' %> for="sunday">
+                        <input type="checkbox" id="sunday" name="sunday" value="true" />
+                        <%= lang.game.options.SUNDAY_SHORT %>
+                    </label>
+                    <label <%- monday ? 'class="btn btn-secondary active"' : 'class="btn btn-secondary"' %> for="monday">
+                        <input type="checkbox" id="monday" name="monday" value="true" />
+                        <%= lang.game.options.MONDAY_SHORT %>
+                    </label>
+                    <label <%- tuesday ? 'class="btn btn-secondary active"' : 'class="btn btn-secondary"' %> for="tuesday">
+                        <input type="checkbox" id="tuesday" name="tuesday" value="true" />
+                        <%= lang.game.options.TUESDAY_SHORT %>
+                    </label>
+                    <label <%- wednesday ? 'class="btn btn-secondary active"' : 'class="btn btn-secondary"' %> for="wednesday">
+                        <input type="checkbox" id="wednesday" name="wednesday" value="true" />
+                        <%= lang.game.options.WEDNESDAY_SHORT %>
+                    </label>
+                    <label <%- thursday ? 'class="btn btn-secondary active"' : 'class="btn btn-secondary"' %> for="thursday">
+                        <input type="checkbox" id="thursday" name="thursday" value="true" />
+                        <%= lang.game.options.THURSDAY_SHORT %>
+                    </label>
+                    <label <%- friday ? 'class="btn btn-secondary active"' : 'class="btn btn-secondary"' %> for="friday">
+                        <input type="checkbox" id="friday" name="friday" value="true" />
+                        <%= lang.game.options.FRIDAY_SHORT %>
+                    </label>
+                    <label <%- saturday ? 'class="btn btn-secondary active"' : 'class="btn btn-secondary"' %> for="saturday">
+                        <input type="checkbox" id="saturday" name="saturday" value="true" />
+                        <%= lang.game.options.SATURDAY_SHORT %>
+                    </label>
+                </div>
+            </div>
+            <div class="form-group col-sm-3">
+                <label for="nextDate" class="col-form-label"><%= lang.game.NEXT_DATE %></label>
+                <input type="date" class="form-control" id="nextDate" name="nextDate" disabled>
+            </div>
+        </div>
+        <div class="row">
             <div class="col-sm-5">
                 <div class="form-group">
                     <label for="reserved" class="col-form-label"><%= lang.game.RESERVED_SLOTS %></label>
@@ -246,6 +296,37 @@
         }
     }).change();
 
+    $('#frequency').change(function() {
+        const sel = $(this).val();
+        $("#weekdays-selector label").addClass("disabled");
+        $('#date').removeAttr("disabled");
+        if (sel === '0') {
+            $('#nextDate').val($('#date').val());
+        }
+        if (sel !== '0') {
+            if (sel !== '1' && sel !== '4') { // disable weekday selection if not repeating weekly or biweekly
+                $('#weekdays-selector label').removeClass("disabled");
+            }
+            updateNextDate($('#date').val(), sel);
+        }
+    });//.change();
+
+    // update date on each click on weekday selector labels
+    $("#weekdays-selector label").map(function() {
+        $(this).mouseup(function() {
+            // we want the function to determine the "valid weekdays" only after the click is finished
+            setTimeout(function() {
+                updateNextDate($('#date').val(), $('#frequency').val());
+            }, 100);
+            
+        });
+    });
+
+    const updateNextDate = (currentDate, freq) => {
+        const nextDate = getRecurrenceDate(currentDate, freq);
+        $('#nextDate').val(nextDate);
+    }
+
     $('#c').change(function() {
         $('#channel').val($('#c option:selected').text())
     }).change();
@@ -307,6 +388,46 @@
         };
     };
 
+    const getRecurrenceDate = (baseDate, frequency) => {
+        if (frequency == 0)
+            return moment(baseDate).format('YYYY-MM-DD');
+
+        const validDays = $("#weekdays-selector label:not(.disabled):not(:disabled).active")
+            .map(function () {
+                return $(this).find("input").attr("id");
+            })
+            .get();
+        var dateGenerator;
+        var nextDate = baseDate;
+
+        switch(frequency) {
+            case '1': // daily
+                nextDate = moment(baseDate).add(1, 'days');
+                break;
+            case '2': // weekly
+                if (validDays === undefined || validDays.length === 0)
+                    break;
+                dateGenerator = moment(baseDate).recur().every(validDays).daysOfWeek();
+                nextDate = dateGenerator.next(1)[0];
+                break;
+            case '3': // biweekly
+                if (validDays === undefined || validDays.length === 0)
+                    break;
+                // this is a compound interval...
+                dateGenerator = moment(baseDate).recur().every(validDays).daysOfWeek();
+                nextDate = dateGenerator.next(1)[0];
+                while(nextDate.week() - moment(baseDate).week() == 1) { // if the next date is in the same week, diff = 0. if it is just next week, diff = 1, so keep going forward.
+                    dateGenerator = moment(nextDate).recur().every(validDays).daysOfWeek();
+                    nextDate = dateGenerator.next(1)[0];
+                }
+                break;
+            case '4': // monthly
+                nextDate = moment(baseDate).add(1, 'month');
+        }
+
+        return moment(nextDate).format('YYYY-MM-DD');
+    }
+
     <% if (is.newgame) { %>
         <% if (date === "") { %>
             $('#date').val(moment().format('YYYY-MM-DD'));
@@ -322,6 +443,7 @@
         $('#convertLink').html(`Time Zone Conversion: <a href="${link.convert}" target="_blank" rel="nofollow">${link.convert}</a>`);
         // $('#countdownLink').html(`Countdown: <a href="${link.countdown}" target="_blank" rel="nofollow">${link.countdown}</a>`);
         $('#gcalLink').html(`<a href="${link.gcal}" target="_blank" rel="nofollow">Add to Calendar</a>`);
+        updateNextDate($('#date').val(), $('#frequency').val());
     }).change();
 
     // $('#date').attr('min', moment().format('YYYY-MM-DD'));
@@ -356,6 +478,17 @@
         }
     });
     <% } %>
+    
+    $('#frequency').change(); // trigger update here to prevent pre-initialization reference error
+
+    // the "active" class on a label doesn't check its corresponding box at page load
+    $('#gameForm').submit(function (event) {
+        $("#weekdays-selector input").map(function () {
+            if($(`label[for=${$(this).attr('id')}]`).hasClass("active")) {
+                $(this).prop("checked", true);
+            }
+        });
+    });
 </script>
 </body>
 </html>


### PR DESCRIPTION
This PR adds support for recurring games in the scheduler.

Changes:

- /games/edit page
  - added frequency selector, weekday selector, and next scheduled date preview fields
    - supported frequencies: daily, weekly, biweekly, monthly
 - upon game creation or edit, the date used for the game event is still what is in "date". "next scheduled date" is only used when the game is automatically rescheduled
- new periodic rescheduling job
  - runs once hourly
  - finds the next date fulfilling the recurring schedule constraints and sets date to that
  - relies on `save()` to update the timestamp of the game to the new date

Screenshots:
game edit page:
![game](https://user-images.githubusercontent.com/2081046/75121009-fa942880-5644-11ea-9d48-19d97d41a3e5.PNG)

past recurring games before rescheduling:
![before](https://user-images.githubusercontent.com/2081046/75121012-fd8f1900-5644-11ea-865f-6628b83c9a0c.png)

games after rescheduling:
![after](https://user-images.githubusercontent.com/2081046/75121010-fd8f1900-5644-11ea-8d94-5cc19c0ba9e9.PNG)

Notes:
- This feature adds more language strings, and I don't speak italian...
- Weekday selector is in format Sun-Sat, which is probably not accurate for all locales.